### PR TITLE
Moved contacts to the top

### DIFF
--- a/PCAxis.Core/Enums/InformationType.vb
+++ b/PCAxis.Core/Enums/InformationType.vb
@@ -1,8 +1,8 @@
 ﻿Namespace PCAxis.Enums
     Public Enum InformationType
+        Contact
         OfficialStatistics
         LastUpdated
-        Contact
         Unit
         RefPeriod
         StockFa


### PR DESCRIPTION
Merge party 2021 v1 fix. Moved Contacts to the top of the enum so that contacts are printed first.